### PR TITLE
add support for partial query results - fix #2

### DIFF
--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -26,9 +26,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
     if (xhr.readyState === 4) {
       if (xhr.status === 200){
         var res = JSON.parse(xhr.responseText);
-        if(res.affected){
+        if(res.affected && res.affected.length > 0){
           //alert("domain "+res.domain+" is affected");
-          switchToAffected();
+          switchToAffected(res.affected);
 
         }else{
           switchToNotAffected();
@@ -120,9 +120,18 @@ document.addEventListener("DOMContentLoaded", function(event) {
     document.location.search = kvp.join('&');
   }
 
-  switchToAffected = function(){
+  switchToAffected = function(affected){
     resetState();
-    resultMsg.innerHTML = "This domain is affected<br>Close all active sessions for this service, change your passwords, and enable 2FA.";
+    let len = affected.length;
+    if(len === 1){
+      resultMsg.innerHTML = "This domain is affected<br>Close all active sessions for this service, change your passwords, and enable 2FA.";
+    } else {
+      resultMsg.innerHTML = "This domain could be affected, but there is no distinct result";
+      for(let i = 0; i < affected.length; i++){
+        resultMsg.innerHTML += "<p>" + affected[i] + "</p>";
+      }
+    }
+    
     removeClass(resultMsg, "hidden");
     addClass(document.body, "affected-state");
 

--- a/public/stylesheets/cover.css
+++ b/public/stylesheets/cover.css
@@ -132,7 +132,7 @@ body {
     top: 0;
   }
   .mastfoot {
-    position: fixed;
+    /*position: fixed;*/
     bottom: 0;
   }
   /* Start the vertical centering */

--- a/routes/check.js
+++ b/routes/check.js
@@ -11,11 +11,23 @@ router.get('/', (req, res, next) => {
 
   if(domain){
 
+    let affected_domains = [];
+    if(domainsDB.indexOf(domain) != -1){
+      affected_domains.push(domain); // distinct result
+    } else {
+      for(let i = 0; i < domainsDB.length; i++){
+        let line = domainsDB[i];
+        if(line.indexOf(domain) >= 0){
+          affected_domains.push(line);
+        }
+      }
+    }
+
     res.status(200);
     res.setHeader('Content-Type', 'application/json');
     res.send(JSON.stringify({
       domain,
-      affected: domainsDB.indexOf(domain) != -1
+      affected: affected_domains
     }));
 
   }else{


### PR DESCRIPTION
This PR will add support for partial query result (#2). The normal affected message is shown if there is a distinct result. If there are partial result, the affected message change to **could be affected** and a list of results will be added below.

Changes:
* the /check route always returns a list of domains instead of true/false. It is a distinct result if there is only one element in the array.
* i've uncomment the position fixed for the footer, otherwise it will screw up the view if there are many results.